### PR TITLE
Added support for complex uris

### DIFF
--- a/lib/Eixo/Rest/Client.pm
+++ b/lib/Eixo/Rest/Client.pm
@@ -13,6 +13,8 @@ use Data::Dumper;
 use Config;
 use Eixo::Rest::RequestSync;
 
+use Eixo::Rest::Uri;
+
 
 my $REQ_PARSER = qr/\:\:([a-z]+)([A-Z]\w+?)$/;
 
@@ -100,7 +102,14 @@ sub AUTOLOAD{
 		};
 	}
 
-	my $uri = $self->build_uri($entity, $id, $action, $args{__implicit_format});
+    my $uri;
+
+    if(my $uri_mask = $args{uri_mask}) {
+        $uri = $self->build_uri_from_mask($uri_mask, \%args);
+    }
+    else{
+	    $uri = $self->build_uri($entity, $id, $action, $args{__implicit_format});
+    }
 
 	$self->$method($uri, %args);
 
@@ -241,6 +250,24 @@ sub build_uri {
         	URI->new($uri.'/'.$self->{format}) :
 
         	URI->new($uri);
+}
+
+sub build_uri_from_mask{
+    my ($self, $uri_mask, $args) = @_;
+
+    my $endpoint = $self->{endpoint};
+    
+    $endpoint .= "/" unless($endpoint =~ /\/$/);
+
+    my $uri = $self->{endpoint} . Eixo::Rest::Uri->new(
+
+        args=>$args->{args},
+
+        uri_mask=>$args->{uri_mask}
+
+    )->build;
+
+    return URI->new($uri)
 }
 
 

--- a/lib/Eixo/Rest/Uri.pm
+++ b/lib/Eixo/Rest/Uri.pm
@@ -1,0 +1,38 @@
+package Eixo::Rest::Uri;
+
+use strict;
+use Eixo::Base::Clase;
+
+my $REG_PARAM = qr/\:(\w+)/;
+
+has(
+
+    args=>undef,
+
+    uri_mask=>undef,
+
+);
+
+sub build{
+    my ($self) = @_;
+
+    my $mask = $self->uri_mask;
+
+    while($mask =~ /$REG_PARAM/g){
+
+        my ($param_name, $param_value) = (
+
+            $1, 
+
+            $self->args->{$1}
+
+        );
+
+        $mask =~ s/\:$param_name/$param_value/g;
+
+    }
+
+    return $mask;
+}
+
+1;

--- a/t/020_client.t
+++ b/t/020_client.t
@@ -19,6 +19,7 @@ SKIP: {
         $pid = Eixo::Rest::ApiFakeServer->new(
 
             listeners => {
+
                 '/containers/json' => {
                     #header => sub {
                     #    print "HTTP/1.0 200 OK\r\n";
@@ -29,6 +30,13 @@ SKIP: {
                         print '[{"a":"TEST1"},{"b":"TEST2"}]';
                     }
                 },
+
+                '/containers/foo/process/a' => {
+
+                    body=> sub {
+                        print '[{"c":"TEST1"},{"d":"TEST2"}]';
+                    }
+                }
             }
         )->start($port);
 
@@ -79,6 +87,40 @@ SKIP: {
         	"Testing json response"
         );
 
+        # complex request
+        my $h = $c->getContainers(
+
+            uri_mask=>"/containers/:name/process/:process",
+
+            args=>{
+                name=>"foo",
+
+                process=>"a"
+            },
+
+            PROCESS_DATA=> {
+
+                onSuccess=>sub {
+                    return $_[0];
+                }
+            },
+
+            __callback=>sub {
+
+                ok(
+
+                    ref($_[0]) eq 'ARRAY' &&
+
+                    $_[0]->[0]->{c} eq 'TEST1' &&
+
+                    $_[0]->[1]->{d} eq 'TEST2',
+
+                    "Complex uri was well formed"
+
+                );
+            }
+
+        );
 
     };
     if($@){

--- a/t/041_uri.t
+++ b/t/041_uri.t
@@ -1,0 +1,24 @@
+use strict;
+use Eixo::Rest::Uri;
+
+use Test::More;
+
+my %args = (
+
+    name=>"foo",
+    organization=>"university"
+);
+
+my $uri = Eixo::Rest::Uri->new(
+
+    args=>\%args,
+
+    uri_mask=>"/organizations/:organization/users/:name"
+
+)->build;
+
+is($uri, "/organizations/university/users/foo", "Uri correctly formed");
+
+
+
+done_testing();


### PR DESCRIPTION
From `now,` we can pass a uri_mask consisting in a string to forma the uri according to the arguments passed to the product. 

``` perl

sub foo{

    $_[0]->getContainers(

      uri_mask=>"/containers/:name/process/:proccess_name",

      name=>"foo",

      process=>1716

   )

}

```
